### PR TITLE
Build OTP for Ubuntu 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
   OTP_RELEASE: 22.0.7
 jobs:
   create_release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -23,7 +23,7 @@ jobs:
   build_and_upload:
     strategy:
       matrix:
-        platform: [ubuntu-18.04, macos-10.15]
+        platform: [ubuntu-20.04, macos-10.15]
         wx: [headless, graphical]
         src: [src, no-src]
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
This is so that we can use it for a hermetic toolchain with Bazel